### PR TITLE
feat: api changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3181,6 +3181,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-3.0.1.tgz",
+      "integrity": "sha512-BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -5305,6 +5310,14 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-4.0.0.tgz",
+      "integrity": "sha512-CazaJJZUPr1EWmHjcntgS1F1q6YOpQROD6Z+aTb9obxgOFsRydnqYkRCh5xDJ3LhqTID46JrWaT7PsF7Oms0PA==",
+      "requires": {
+        "prepend-http": "^3.0.1"
       }
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   },
   "lint-staged": {
     "*.js": "npm run fix"
+  },
+  "dependencies": {
+    "url-parse-lax": "^4.0.0"
   }
 }

--- a/src/spike/constants.js
+++ b/src/spike/constants.js
@@ -5,5 +5,13 @@ module.exports = {
   ALGORITHM_FIELD_PREFIX: 'algorithm=',
   DELIMITER: ': ',
   SPACE: ' ',
-  COMMA: ', '
+  COMMA: ', ',
+  NEWLINE: '\n',
+  BASE_64: 'base64',
+  SHA_256: 'sha256',
+  SHA_256_PREFIX: 'SHA-256',
+  SHA_512: 'sha512',
+  // TODO(jkirkpatrick24): replace with capitalized SHA-512.
+  SHA_512_PREFIX: 'sha-512',
+  EXPIRATION_OFFSET: 300
 }

--- a/src/spike/constants.js
+++ b/src/spike/constants.js
@@ -1,0 +1,9 @@
+module.exports = {
+  HEADERS_FIELD_PREFIX: 'headers=',
+  SIGNATURE_FIELD_PREFIX: 'signature=',
+  KEY_ID_FIELD_PREFIX: 'keyId=',
+  ALGORITHM_FIELD_PREFIX: 'algorithm=',
+  DELIMITER: ': ',
+  SPACE: ' ',
+  COMMA: ', '
+}

--- a/src/spike/constructSignature.js
+++ b/src/spike/constructSignature.js
@@ -1,5 +1,6 @@
 const { createHmac } = require('crypto')
+const { BASE_64 } = require('./constants')
 
 module.exports = function constructSignature (secret, algorithm, input) {
-  return createHmac(algorithm, secret).update(input).digest('base64').toString()
+  return createHmac(algorithm, secret).update(input).digest(BASE_64).toString()
 }

--- a/src/spike/constructSignature.js
+++ b/src/spike/constructSignature.js
@@ -1,0 +1,5 @@
+const { createHmac } = require('crypto')
+
+module.exports = function constructSignature (secret, algorithm, input) {
+  return createHmac(algorithm, secret).update(input).digest('base64').toString()
+}

--- a/src/spike/constructSignatureString.js
+++ b/src/spike/constructSignatureString.js
@@ -1,0 +1,44 @@
+const {
+  HEADERS_FIELD_PREFIX,
+  SIGNATURE_FIELD_PREFIX,
+  KEY_ID_FIELD_PREFIX,
+  ALGORITHM_FIELD_PREFIX,
+  DELIMITER,
+  SPACE,
+  COMMA
+} = require('./constants')
+
+function joinField (key, value) {
+  return `${key}"${value}"`
+}
+
+function headerFieldReducer (accumulator, [key]) {
+  return accumulator.concat(key, SPACE)
+};
+
+function signatureHeaderInputReducer (accumulator, [key, value]) {
+  return accumulator.concat(key, DELIMITER, value, SPACE)
+};
+
+module.exports = function constructSignatureString (request, opts) {
+  const {
+    secret,
+    constructSignature,
+    keyId,
+    algorithm,
+    fields
+  } = opts
+  const signedHeaders = fields.reduce(signatureHeaderInputReducer, '').trim()
+  const signature = constructSignature(secret, algorithm, signedHeaders)
+  const headerField = joinField(HEADERS_FIELD_PREFIX, fields.reduce(headerFieldReducer, '').trim())
+  const keyIdField = joinField(KEY_ID_FIELD_PREFIX, keyId)
+  const algorithmField = joinField(ALGORITHM_FIELD_PREFIX, algorithm)
+  const signatureField = joinField(SIGNATURE_FIELD_PREFIX, signature)
+
+  return [
+    keyIdField,
+    algorithmField,
+    headerField,
+    signatureField
+  ].join(COMMA).trim()
+}

--- a/src/spike/constructSignatureString.js
+++ b/src/spike/constructSignatureString.js
@@ -4,6 +4,7 @@ const {
   KEY_ID_FIELD_PREFIX,
   ALGORITHM_FIELD_PREFIX,
   DELIMITER,
+  NEWLINE,
   SPACE,
   COMMA
 } = require('./constants')
@@ -17,7 +18,7 @@ function headerFieldReducer (accumulator, [key]) {
 };
 
 function signatureHeaderInputReducer (accumulator, [key, value]) {
-  return accumulator.concat(key, DELIMITER, value, SPACE)
+  return accumulator.concat(key, DELIMITER, value, NEWLINE)
 };
 
 module.exports = function constructSignatureString (request, opts) {
@@ -26,10 +27,12 @@ module.exports = function constructSignatureString (request, opts) {
     constructSignature,
     keyId,
     algorithm,
+    signingAlgorithm,
     fields
   } = opts
+
   const signedHeaders = fields.reduce(signatureHeaderInputReducer, '').trim()
-  const signature = constructSignature(secret, algorithm, signedHeaders)
+  const signature = constructSignature(secret, signingAlgorithm, signedHeaders)
   const headerField = joinField(HEADERS_FIELD_PREFIX, fields.reduce(headerFieldReducer, '').trim())
   const keyIdField = joinField(KEY_ID_FIELD_PREFIX, keyId)
   const algorithmField = joinField(ALGORITHM_FIELD_PREFIX, algorithm)

--- a/src/spike/defaultOpts.js
+++ b/src/spike/defaultOpts.js
@@ -1,0 +1,21 @@
+const extractors = require('./extractors')
+const transformers = require('./transformers')
+const constructSignature = require('./constructSignature')
+const constructSignatureString = require('./constructSignatureString')
+const outputHandler = require('./outputHandler')
+
+const signatureFields = [
+  '(request-target)',
+  'Date'
+]
+
+module.exports = {
+  algorithm: 'hs2019',
+  signingAlgorithm: 'sha512',
+  signatureFields,
+  extractors,
+  transformers,
+  constructSignatureString,
+  constructSignature,
+  outputHandler
+}

--- a/src/spike/extractors.js
+++ b/src/spike/extractors.js
@@ -1,0 +1,12 @@
+const urlParseLax = require('url-parse-lax')
+const { SPACE } = require('./constants')
+
+module.exports = {
+  '(request-target)': (req) => {
+    const { method, url } = req
+    const { pathname, search } = urlParseLax(url)
+    return [method.toLowerCase(), pathname, search].join(SPACE)
+  },
+  'Content-Type': (req) => req.headers['Content-Type'],
+  Digest: (req) => req.body
+}

--- a/src/spike/extractors.js
+++ b/src/spike/extractors.js
@@ -1,12 +1,21 @@
 const urlParseLax = require('url-parse-lax')
-const { SPACE } = require('./constants')
+
+const { SPACE, EXPIRATION_OFFSET } = require('./constants')
 
 module.exports = {
   '(request-target)': (req) => {
     const { method, url } = req
     const { pathname, search } = urlParseLax(url)
-    return [method.toLowerCase(), pathname, search].join(SPACE)
+    return [method.toLowerCase(), pathname, search].join(SPACE).trim()
   },
+  '(created)': (req) => parseInt(req.headers.Date),
+  '(expires)': (req) => parseInt(req.headers.Date) + EXPIRATION_OFFSET,
   'Content-Type': (req) => req.headers['Content-Type'],
-  Digest: (req) => req.body
+  'Content-Length': (req) => req.headers['Content-Length'],
+  Digest: (req) => req.body,
+  Date: (req) => req.headers.Date,
+  Host: ({ url }) => {
+    const { host } = urlParseLax(url)
+    return host
+  }
 }

--- a/src/spike/index.js
+++ b/src/spike/index.js
@@ -1,6 +1,11 @@
 const processor = require('./processor')
+const defaultOpts = require('./defaultOpts')
 
-module.exports = function createRequestSigner (opts) {
+module.exports = function createRequestSigner (options) {
+  const opts = {
+    ...defaultOpts,
+    ...options
+  }
   const {
     constructSignatureString,
     extractors,

--- a/src/spike/index.js
+++ b/src/spike/index.js
@@ -1,0 +1,27 @@
+const processor = require('./processor')
+
+module.exports = function createRequestSigner (opts) {
+  const {
+    constructSignatureString,
+    extractors,
+    signatureFields,
+    transformers,
+    outputHandler,
+    ...restOpts
+  } = opts
+  return function requestSigner (request) {
+    const fields = signatureFields.map((field) => processor(
+      request,
+      field,
+      extractors,
+      transformers
+    )).filter(([, value]) => value)
+
+    const signature = constructSignatureString(request, {
+      ...restOpts,
+      fields
+    })
+
+    return outputHandler(request, fields, signature)
+  }
+}

--- a/src/spike/index.test.js
+++ b/src/spike/index.test.js
@@ -1,40 +1,45 @@
 const { test } = require('tap')
 
-const createSignedRequest = require('./index.js')
-const extractors = require('./extractors')
-const transformers = require('./transformers')
-const constructSignature = require('./constructSignature')
-const constructSignatureString = require('./constructSignatureString')
-const outputHandler = require('./outputHandler')
+const createSignedRequest = require('.')
 
-test('the thing', ({ fail }) => {
+test('createSignedRequest', async ({ same }) => {
   const signatureFields = [
     '(request-target)',
-    'Content-Type',
-    'Digest'
+    '(created)',
+    '(expires)',
+    'Host',
+    'Digest',
+    'Content-Type'
   ]
 
   const opts = {
-    secret: 'topsecret',
-    keyId: 'testkey',
-    algorithm: 'sha512',
-    signatureFields,
-    extractors,
-    transformers,
-    constructSignatureString,
-    constructSignature,
-    outputHandler
+    secret: 'topSecret',
+    keyId: 'test-key-a',
+    signatureFields
   }
 
   const request = {
-    url: 'https://google.com',
+    url: 'http://localhost:3000/foo',
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ hello: 'world' })
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      Date: 1602872645,
+      'Content-Type': 'application/json'
+    }
   }
 
   const signRequest = createSignedRequest(opts)
   const actual = signRequest(request)
-  console.log(actual)
-  fail()
+  const expected = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      Date: 1602872645,
+      'Content-Type': 'application/json',
+      Digest: 'sha-512=+PtokCNHosgo04ww4cNhd4yJxhMjLzWjDAKtKwQZDT4Ef9v/PrS/+BQLX4IX5dZkUMK/tQo7Uyc68RkhNyCZVg==',
+      Signature: 'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) host digest content-type", signature="HFIn7RU3zvfFHeyOjsRlMzUQ18prW+KE61ikKKKoyAlcxGUdlBF/sruA+VznOhQNlWh3J4y3tZc8aDa0TxRBEg=="'
+    }
+  }
+  same(actual, expected)
 })

--- a/src/spike/index.test.js
+++ b/src/spike/index.test.js
@@ -1,0 +1,40 @@
+const { test } = require('tap')
+
+const createSignedRequest = require('./index.js')
+const extractors = require('./extractors')
+const transformers = require('./transformers')
+const constructSignature = require('./constructSignature')
+const constructSignatureString = require('./constructSignatureString')
+const outputHandler = require('./outputHandler')
+
+test('the thing', ({ fail }) => {
+  const signatureFields = [
+    '(request-target)',
+    'Content-Type',
+    'Digest'
+  ]
+
+  const opts = {
+    secret: 'topsecret',
+    keyId: 'testkey',
+    algorithm: 'sha512',
+    signatureFields,
+    extractors,
+    transformers,
+    constructSignatureString,
+    constructSignature,
+    outputHandler
+  }
+
+  const request = {
+    url: 'https://google.com',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ hello: 'world' })
+  }
+
+  const signRequest = createSignedRequest(opts)
+  const actual = signRequest(request)
+  console.log(actual)
+  fail()
+})

--- a/src/spike/index.test.js
+++ b/src/spike/index.test.js
@@ -43,3 +43,218 @@ test('createSignedRequest', async ({ same }) => {
   }
   same(actual, expected)
 })
+
+test('createSignedRequest - allows a user to override the extractors', async ({ same }) => {
+  const signatureFields = [
+    '(request-target)',
+    '(created)',
+    '(expires)',
+    'Date',
+    'Content-Length'
+  ]
+
+  const defaultExtractors = require('./extractors')
+
+  const opts = {
+    secret: 'topSecret',
+    keyId: 'test-key-a',
+    signatureFields,
+    extractors: {
+      ...defaultExtractors,
+      '(expires)': () => 1234567888
+    }
+  }
+
+  const request = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      Date: 1602872645,
+      'Content-Type': 'application/json',
+      'Content-Length': JSON.stringify({ hello: 'world' }).length
+    }
+  }
+
+  const signRequest = createSignedRequest(opts)
+  const actual = signRequest(request)
+  const expected = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    body: JSON.stringify({ hello: 'world' }),
+    headers: {
+      Date: 1602872645,
+      'Content-Type': 'application/json',
+      'Content-Length': JSON.stringify({ hello: 'world' }).length,
+      Signature: 'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) (expires) date content-length", signature="eSw1Nun8RPvj6p4Nx2/gK7edAJNa+FT+UnyFvjBaJcUNltB2zS2LjrYs6bmkRQbgIFyvqPgSp/ZqF68qbnmyrw=="'
+    }
+  }
+  same(actual, expected)
+})
+
+test('createSignedRequest - allows a user to override the extractors', async ({ same }) => {
+  const signatureFields = [
+    '(request-target)',
+    '(created)',
+    'Date'
+  ]
+
+  const opts = {
+    secret: 'topSecret',
+    keyId: 'test-key-a',
+    signatureFields,
+    transformers: {
+      Date: (key, value) => [key.toUpperCase(), 11111111111]
+    }
+  }
+
+  const request = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645
+    }
+  }
+
+  const signRequest = createSignedRequest(opts)
+  const actual = signRequest(request)
+  const expected = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645,
+      Signature: 'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created) DATE", signature="pjzjxAYIk6RjGSvB8oA3u06ThAFWAEGD6pWBOjFVSB/H4+tzPoPZUiG21uGBCWVi7AOyOy/2dWf+WYH8FsZlwg=="'
+    }
+  }
+  same(actual, expected)
+})
+
+test('createSignedRequest - allows a user to override the constructSignature method', async ({ same }) => {
+  const signatureFields = [
+    '(request-target)',
+    '(created)'
+  ]
+
+  const opts = {
+    secret: 'topSecret',
+    keyId: 'test-key-a',
+    signatureFields,
+    constructSignature: (secret, algorithm, input) =>
+      [secret, algorithm, input].join('::')
+  }
+
+  const request = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645
+    }
+  }
+
+  const signRequest = createSignedRequest(opts)
+  const actual = signRequest(request)
+  const expected = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645,
+      Signature: 'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created)", signature="topSecret::sha512::(request-target): post /foo\n(created): 1602872645"'
+    }
+  }
+  same(actual, expected)
+})
+
+test('createSignedRequest - allows a user to override the constructSignatureString method', async ({ same }) => {
+  const signatureFields = [
+    '(request-target)',
+    '(created)'
+  ]
+
+  const opts = {
+    secret: 'topSecret',
+    keyId: 'test-key-a',
+    signatureFields,
+    constructSignatureString: (request, opts) => {
+      const {
+        algorithm,
+        signingAlgorithm,
+        constructSignature,
+        secret,
+        keyId,
+        fields
+      } = opts
+      const signature = constructSignature(secret, signingAlgorithm, 'asdf')
+      return `algorithm=${algorithm} :: keyId=${keyId}::  fields=${fields.join('--')} :: signature=${signature}}`
+    }
+  }
+
+  const request = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645
+    }
+  }
+
+  const signRequest = createSignedRequest(opts)
+  const actual = signRequest(request)
+  const expected = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645,
+      Signature: 'algorithm=hs2019 :: keyId=test-key-a::  fields=(request-target),post /foo--(created),1602872645 :: signature=7Ng9s9iT1jMhqtY68sDrEo5EquExrEwRTkFjuIwbynXW6NzI/zV37M9rglDH3JVpFpsjvGau7aa2ufXSwQrv0Q==}'
+    }
+  }
+  same(actual, expected)
+})
+
+test('createSignedRequest - allows a user to override the outputHandler method', async ({ same }) => {
+  const signatureFields = [
+    '(request-target)',
+    '(created)'
+  ]
+
+  const opts = {
+    secret: 'topSecret',
+    keyId: 'test-key-a',
+    signatureFields,
+    outputHandler: (request, fields, signature) => ({
+      request,
+      fields,
+      signature
+    })
+  }
+
+  const request = {
+    url: 'http://localhost:3000/foo',
+    method: 'POST',
+    headers: {
+      Date: 1602872645
+    }
+  }
+
+  const signRequest = createSignedRequest(opts)
+  const actual = signRequest(request)
+  const expected = {
+    request: {
+      url: 'http://localhost:3000/foo',
+      method: 'POST',
+      headers: {
+        Date: 1602872645
+      }
+    },
+    fields: [
+      [
+        '(request-target)',
+        'post /foo'
+      ],
+      [
+        '(created)',
+        1602872645
+      ]
+    ],
+    signature: 'keyId="test-key-a", algorithm="hs2019", headers="(request-target) (created)", signature="+H6Yip7T+tbRyz2Ho+WCEKxr+h2xL/xR3aH8PobEoyL6uWyv20+gKacMmyqeEfg9X26tL9h9vhA4GphTS1A1EQ=="'
+  }
+  same(actual, expected)
+})

--- a/src/spike/outputHandler.js
+++ b/src/spike/outputHandler.js
@@ -1,0 +1,8 @@
+module.exports = function outputHandler (request, fields, signature) {
+  const [, digest] = fields.find(([key, value]) => key === 'digest')
+  if (digest) {
+    request.headers.Digest = digest
+  }
+  request.headers.Signature = signature
+  return request
+}

--- a/src/spike/outputHandler.js
+++ b/src/spike/outputHandler.js
@@ -1,5 +1,5 @@
 module.exports = function outputHandler (request, fields, signature) {
-  const [, digest] = fields.find(([key, value]) => key === 'digest')
+  const [, digest] = fields.find(([key, value]) => key === 'digest') || []
   if (digest) {
     request.headers.Digest = digest
   }

--- a/src/spike/processor.js
+++ b/src/spike/processor.js
@@ -1,5 +1,5 @@
 function defaultTransformer (key, value) {
-  return [key, value]
+  return [key.toLowerCase(), value]
 }
 
 module.exports = function processor (request, field, extractors, transformers) {

--- a/src/spike/processor.js
+++ b/src/spike/processor.js
@@ -1,0 +1,10 @@
+function defaultTransformer (key, value) {
+  return [key, value]
+}
+
+module.exports = function processor (request, field, extractors, transformers) {
+  const extractor = extractors[field]
+  const transformer = transformers[field] || defaultTransformer
+  const fieldValue = extractor(request)
+  return transformer(field, fieldValue)
+}

--- a/src/spike/transformers.js
+++ b/src/spike/transformers.js
@@ -1,9 +1,12 @@
 const { createHash } = require('crypto')
+const { BASE_64, SHA_512, SHA_512_PREFIX } = require('./constants')
 
 module.exports = {
-  'Content-Type': (key, value) => [key.toLowerCase(), value],
   Digest: (key, value) => [
     key.toLowerCase(),
-    createHash('sha512').update(value).digest('base64').toString()
+    [
+      SHA_512_PREFIX,
+      createHash(SHA_512).update(value).digest(BASE_64).toString()
+    ].join('=')
   ]
 }

--- a/src/spike/transformers.js
+++ b/src/spike/transformers.js
@@ -1,0 +1,9 @@
+const { createHash } = require('crypto')
+
+module.exports = {
+  'Content-Type': (key, value) => [key.toLowerCase(), value],
+  Digest: (key, value) => [
+    key.toLowerCase(),
+    createHash('sha512').update(value).digest('base64').toString()
+  ]
+}


### PR DESCRIPTION
# Summary

This PR proposes a new API and configuration for this module. The idea is to maximize the flexibility, while keeping the API simple for most users.

Adds a top level `createRequestSigner` method, that accepts a configuration object and returns a function that accepts a request object and returns that request object with a complete hmac signed `Signature` header (by default).

The key components of the configuration object are: `signatureFields`, `extractors` and `transformers`.

`signatureFields` are the components that will be passed as an input to be signed (often things like the 'Content-Type' header, body digest etc).

`extractors` are functions that are called for each field in the signatureFields array and should return whatever value  that signature field should contain. For example, an extractor for the 'Content-Type' header, should simply return the value of that header. Each signature field should have a corresponding extractor method.

`transformers` are functions that receive the signature field and its corresponding value, and may carry out any additional transformations to the key/value pair it must return a tuple with the key + value entries. For example:

`'Content-Type': (key, value) => [key.toLowerCase(), value],  // lowercase the header field`.

Once these transformations are carried out, the results are passed to a method that will construct a string with all the fields and then sign it using a provided secret. (This method is also configurable)

Once the string is constructed, it is passed to a final "outputHandler" function that is called with the request object the signature string, and the input fields used to construct that signature, you may do any other processing of the request object here. The default behaviour is to add the signature string to the request as a `Signature` header as well as add a `Digest` header if the digest was calculated.

## TODOs

Seeing as this is just an RC, we still need to add some functionality - mainly documentation of the API and some error messaging/handling.

- [ ] - validate inputs + outputs
- [ ] - error messaging and handling
- [ ] - docs

