### PR TITLE
Refactor/structure to support multiple ietf draft versions

### DIFF
--- a/src/spike/constants.js
+++ b/src/spike/constants.js
@@ -1,10 +1,6 @@
+'use strict'
+
 module.exports = {
-  HEADERS_FIELD_PREFIX: 'headers=',
-  SIGNATURE_FIELD_PREFIX: 'signature=',
-  KEY_ID_FIELD_PREFIX: 'keyId=',
-  ALGORITHM_FIELD_PREFIX: 'algorithm=',
-  CREATED_FIELD_PREFIX: 'created=',
-  EXPIRES_FIELD_PREFIX: 'expires=',
   DELIMITER: ': ',
   SPACE: ' ',
   COMMA: ', ',

--- a/src/spike/defaultOpts.js
+++ b/src/spike/defaultOpts.js
@@ -1,13 +1,13 @@
-const extractors = require('./extractors')
-const transformers = require('./transformers')
-const constructSignature = require('./constructSignature')
-const constructSignatureString = require('./constructSignatureString')
-const outputHandler = require('./outputHandler')
+'use strict'
 
-const signatureFields = [
-  '(request-target)',
-  'Date'
-]
+const {
+  constructSignature,
+  constructSignatureString,
+  outputHandler,
+  transformers,
+  extractors,
+  signatureFields
+} = require('./defaults/versions/latest')
 
 module.exports = {
   algorithm: 'hs2019',

--- a/src/spike/defaults/versions/latest/index.js
+++ b/src/spike/defaults/versions/latest/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('../v00')

--- a/src/spike/defaults/versions/v00/constants.js
+++ b/src/spike/defaults/versions/v00/constants.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = {
+  HEADERS_FIELD_PREFIX: 'headers=',
+  SIGNATURE_FIELD_PREFIX: 'signature=',
+  KEY_ID_FIELD_PREFIX: 'keyId=',
+  ALGORITHM_FIELD_PREFIX: 'algorithm=',
+  CREATED_FIELD_PREFIX: 'created=',
+  EXPIRES_FIELD_PREFIX: 'expires='
+}

--- a/src/spike/defaults/versions/v00/constructSignature.js
+++ b/src/spike/defaults/versions/v00/constructSignature.js
@@ -1,5 +1,7 @@
+'use strict'
+
 const { createHmac } = require('crypto')
-const { BASE_64 } = require('./constants')
+const { BASE_64 } = require('../../../constants')
 
 module.exports = function constructSignature (secret, algorithm, input) {
   return createHmac(algorithm, secret).update(input).digest(BASE_64).toString()

--- a/src/spike/defaults/versions/v00/constructSignatureString.js
+++ b/src/spike/defaults/versions/v00/constructSignatureString.js
@@ -1,14 +1,18 @@
+'use strict'
+
+const {
+  DELIMITER,
+  NEWLINE,
+  SPACE,
+  COMMA
+} = require('../../../constants')
 const {
   HEADERS_FIELD_PREFIX,
   SIGNATURE_FIELD_PREFIX,
   KEY_ID_FIELD_PREFIX,
   ALGORITHM_FIELD_PREFIX,
   CREATED_FIELD_PREFIX,
-  EXPIRES_FIELD_PREFIX,
-  DELIMITER,
-  NEWLINE,
-  SPACE,
-  COMMA
+  EXPIRES_FIELD_PREFIX
 } = require('./constants')
 
 function joinField (key, value) {

--- a/src/spike/defaults/versions/v00/extractors.js
+++ b/src/spike/defaults/versions/v00/extractors.js
@@ -1,6 +1,6 @@
 const urlParseLax = require('url-parse-lax')
 
-const { SPACE, EXPIRATION_OFFSET } = require('./constants')
+const { SPACE, EXPIRATION_OFFSET } = require('../../../constants')
 
 module.exports = {
   '(request-target)': (req) => {

--- a/src/spike/defaults/versions/v00/index.js
+++ b/src/spike/defaults/versions/v00/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const constructSignature = require('./constructSignature')
+const constructSignatureString = require('./constructSignatureString')
+const outputHandler = require('./outputHandler')
+const transformers = require('./transformers')
+const extractors = require('./extractors')
+const signatureFields = require('./signatureFields')
+
+module.exports = {
+  constructSignatureString,
+  constructSignature,
+  outputHandler,
+  transformers,
+  extractors,
+  signatureFields
+}

--- a/src/spike/defaults/versions/v00/outputHandler.js
+++ b/src/spike/defaults/versions/v00/outputHandler.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = function outputHandler (request, fields, signature) {
   const [, digest] = fields.find(([key, value]) => key === 'digest') || []
   if (digest) {

--- a/src/spike/defaults/versions/v00/signatureFields.js
+++ b/src/spike/defaults/versions/v00/signatureFields.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const signatureFields = [
+  '(request-target)',
+  'Date'
+]
+
+module.exports = signatureFields

--- a/src/spike/defaults/versions/v00/transformers.js
+++ b/src/spike/defaults/versions/v00/transformers.js
@@ -1,5 +1,5 @@
 const { createHash } = require('crypto')
-const { BASE_64, SHA_512, SHA_512_PREFIX } = require('./constants')
+const { BASE_64, SHA_512, SHA_512_PREFIX } = require('../../../constants')
 
 module.exports = {
   Digest: (key, value) => [

--- a/src/spike/index.test.js
+++ b/src/spike/index.test.js
@@ -94,7 +94,7 @@ test('createSignedRequest - allows a user to override the extractors', async ({ 
     'Content-Length'
   ]
 
-  const defaultExtractors = require('./extractors')
+  const defaultExtractors = require('./defaults/versions/v00/extractors')
 
   const opts = {
     secret: 'topSecret',


### PR DESCRIPTION
# Summary

Refactored the directory structure to allow support for multiple ietf draft standards moving forward. Defaults that conform to these standards are now exported from a `defaults/versions/<v number>` directory. The package by default will consume the version exported from the `latest` version, which is a re-export of the most recently implemented draft standard.

There are no functional changes with the change set.